### PR TITLE
Add means to check for DSA/IAA device presence on user platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ There are several reasons for this:
 
 First, please check your CPU platform, make sure you have IAA or DSA devices.
 
+```shell
+ls -df /sys/bus/dsa/devices/dsa* # lists all DSA devices if present. Only <path>/dsa<id> are devices.
+ls -df /sys/bus/dsa/devices/iax* # lists all IAA devices if present.
+```
+
 Then, use the command below to check whether the workqueues have been configured.
 
 ```shell


### PR DESCRIPTION
 Adding commands using linux sysfs file system to check for the
 presence of DSA/IAA devices on the user platform.
 The use of "accel-config list" only can be misleading as it only
 provides information as to whether the device is configured or not.
 The user can still miss the presence of an unconfigured device.